### PR TITLE
fix: add fallback when the arial font doesn't exist

### DIFF
--- a/nodes/FL_ImageNotes.py
+++ b/nodes/FL_ImageNotes.py
@@ -1,3 +1,4 @@
+import os
 import torch
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
@@ -40,7 +41,11 @@ class FL_ImageNotes:
         new_image.paste(image, (0, bar_height))
 
         draw = ImageDraw.Draw(new_image)
-        font = ImageFont.truetype("arial.ttf", text_size)
+
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        font_path = os.path.join(current_dir, "..", "fonts", "arial.ttf")
+        
+        font = ImageFont.truetype(font_path, text_size)
         text_width, text_height = self.get_text_size(text, font)
         x = (width - text_width) // 2
         y = (bar_height - text_height) // 2


### PR DESCRIPTION
I'm using this in a linux container, the problem is that arial font doesn't exist there.
We're getting this error:
```
  File "/comfyui/execution.py", line 323, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/comfyui/execution.py", line 198, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/comfyui/execution.py", line 169, in _map_node_over_list
    process_inputs(input_dict, i)
  File "/comfyui/execution.py", line 158, in process_inputs
    results.append(getattr(obj, func)(**inputs))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/comfyui/custom_nodes/ComfyUI_Fill-Nodes/nodes/FL_ImageNotes.py", line 28, in add_notes
    result_img = self.add_text_bar(img, text, bar_height, text_size)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/comfyui/custom_nodes/ComfyUI_Fill-Nodes/nodes/FL_ImageNotes.py", line 43, in add_text_bar
    font = ImageFont.truetype("arial.ttf", text_size)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/PIL/ImageFont.py", line 834, in truetype
    return freetype(font)
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/PIL/ImageFont.py", line 831, in freetype
    return FreeTypeFont(font, size, index, encoding, layout_engine)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/PIL/ImageFont.py", line 257, in __init__
    self.font = core.getfont(
                ^^^^^^^^^^^^^
OSError: cannot open resource
```

Using `DejaVuSans.ttf` as a fallback because looks that it's in most major Linux distributions.