### PR TITLE
fix: No module named 'diffusers'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+diffusers
 librosa
 sounddevice
 glitch_this


### PR DESCRIPTION
I was getting this error in a clean comfyUI installation (without other custom nodes)

```
No OpenGL_accelerate module loaded: No module named 'OpenGL_accelerate'
Failed to load library ( 'libOpenGL.so.0' ): libOpenGL.so.0: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "/comfyui/nodes.py", line 2108, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/comfyui/custom_nodes/ComfyUI_Fill-Nodes-fix-FL-image-notes/__init__.py", line 91, in <module>
    from .nodes.FL_HunyuanDelight import FL_HunyuanDelight
  File "/comfyui/custom_nodes/ComfyUI_Fill-Nodes-fix-FL-image-notes/nodes/FL_HunyuanDelight.py", line 6, in <module>
    from diffusers import StableDiffusionInstructPix2PixPipeline, EulerAncestralDiscreteScheduler
ModuleNotFoundError: No module named 'diffusers'

Cannot import /comfyui/custom_nodes/ComfyUI_Fill-Nodes-fix-FL-image-notes module for custom nodes: No module named 'diffusers'
```

I think this usually is not a problem because it is not usual to have only 1 custom node, so I'm thinking that some of all the other custom nodes are installing it and that is why doesn't fail.