### PR TITLE
Replace deprecated: deselectAllNodes -> deselectAll

### DIFF
--- a/web/nodes/fl_js.js
+++ b/web/nodes/fl_js.js
@@ -363,7 +363,7 @@ const remove = function(...nodes) {
 
 const select = function(...nodes) {
   nodes = nodes.map(findNode);
-  app.canvas.deselectAllNodes();
+  app.canvas.deselectAll();
   app.canvas.selectNodes(nodes);
 }
 

--- a/web/nodes/fl_wf_agent.js
+++ b/web/nodes/fl_wf_agent.js
@@ -510,7 +510,7 @@ const remove = function(...nodes) {
 
 const select = function(...nodes) {
   nodes = nodes.map(findNode);
-  app.canvas.deselectAllNodes();
+  app.canvas.deselectAll();
   app.canvas.selectNodes(nodes);
 }
 


### PR DESCRIPTION
`deselectAll` was added on 2024-11-06; `deselectAllNodes` is now an alias that will eventually be removed.