### PR TITLE
Don't resolve symlinks for ROOT path

### DIFF
--- a/nodes/sup.py
+++ b/nodes/sup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 ### GLOBALS
 
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = Path(__file__).absolute().parent.parent
 ROOT_COMFY = ROOT.parent.parent
 ROOT_FONTS = ROOT / "fonts"
 


### PR DESCRIPTION
Path.resolve makes a Path absolute but also resolves symlinks, which is problematic if the custom_nodes folder itself is a symbolic link (as it might be inside a Docker container to make mounting easier, in my case). I don’t see why we would need to both resolve and make it absolute in the first place, but I kept the part that makes it absolute anyway.