### PR TITLE
Dynamically populate Sampler/Scheduler string node

### DIFF
--- a/nodes/ksamplers/FL_SamplerStrings.py
+++ b/nodes/ksamplers/FL_SamplerStrings.py
@@ -1,35 +1,11 @@
+import comfy.samplers
+
 class FL_SamplerStrings:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "euler": ("BOOLEAN", {"default": False}),
-                "euler_cfg_pp": ("BOOLEAN", {"default": False}),
-                "euler_ancestral": ("BOOLEAN", {"default": False}),
-                "euler_ancestral_cfg_pp": ("BOOLEAN", {"default": False}),
-                "heun": ("BOOLEAN", {"default": False}),
-                "heunpp2": ("BOOLEAN", {"default": False}),
-                "dpm_2": ("BOOLEAN", {"default": False}),
-                "dpm_2_ancestral": ("BOOLEAN", {"default": False}),
-                "lms": ("BOOLEAN", {"default": False}),
-                "dpm_fast": ("BOOLEAN", {"default": False}),
-                "dpm_adaptive": ("BOOLEAN", {"default": False}),
-                "dpmpp_2s_ancestral": ("BOOLEAN", {"default": False}),
-                "dpmpp_sde": ("BOOLEAN", {"default": False}),
-                "dpmpp_sde_gpu": ("BOOLEAN", {"default": False}),
-                "dpmpp_2m": ("BOOLEAN", {"default": False}),
-                "dpmpp_2m_sde": ("BOOLEAN", {"default": False}),
-                "dpmpp_2m_sde_gpu": ("BOOLEAN", {"default": False}),
-                "dpmpp_3m_sde": ("BOOLEAN", {"default": False}),
-                "dpmpp_3m_sde_gpu": ("BOOLEAN", {"default": False}),
-                "ddpm": ("BOOLEAN", {"default": False}),
-                "lcm": ("BOOLEAN", {"default": False}),
-                "ipndm": ("BOOLEAN", {"default": False}),
-                "ipndm_v": ("BOOLEAN", {"default": False}),
-                "deis": ("BOOLEAN", {"default": False}),
-                "ddim": ("BOOLEAN", {"default": False}),
-                "uni_pc": ("BOOLEAN", {"default": False}),
-                "uni_pc_bh2": ("BOOLEAN", {"default": False}),
+                sampler: ("BOOLEAN", {"default": False}) for sampler in comfy.samplers.KSampler.SAMPLERS
             }
         }
 

--- a/nodes/ksamplers/FL_SchedulerStrings.py
+++ b/nodes/ksamplers/FL_SchedulerStrings.py
@@ -1,15 +1,11 @@
+import comfy.samplers
+
 class FL_SchedulerStrings:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "normal": ("BOOLEAN", {"default": False}),
-                "karras": ("BOOLEAN", {"default": False}),
-                "exponential": ("BOOLEAN", {"default": False}),
-                "sgm_uniform": ("BOOLEAN", {"default": False}),
-                "simple": ("BOOLEAN", {"default": False}),
-                "ddim_uniform": ("BOOLEAN", {"default": False}),
-                "beta": ("BOOLEAN", {"default": False}),
+                scheduler: ("BOOLEAN", {"default": False}) for scheduler in comfy.samplers.KSampler.SCHEDULERS
             }
         }
 


### PR DESCRIPTION
Updated FL_SamplerStrings.py and FL_SchedulerStrings.py to display all of the schedulers/samplers available to them.

Obviously that list can get quite long, but I just hide the ones I don't care about by wrapping the node in a subgraph.