### PR TITLE
Preserve original queue prompt error source

### DIFF
--- a/web/nodes/utility/fl_js.js
+++ b/web/nodes/utility/fl_js.js
@@ -626,10 +626,9 @@ app.registerExtension({
   async setup() {
     setTimeout(() => {
       const origQueuePrompt = app.queuePrompt;
-      app.queuePrompt = async function(...args) {
+      app.queuePrompt = function(...args) {
         execNodes("before_queued", args);
-        const r = await origQueuePrompt.apply(this, arguments);
-        return r;
+        return origQueuePrompt.apply(this, args);
       }
   
       api.addEventListener("promptQueued", function(...args) {

--- a/web/nodes/wip/fl_wf_agent.js
+++ b/web/nodes/wip/fl_wf_agent.js
@@ -773,10 +773,9 @@ app.registerExtension({
   async setup() {
     setTimeout(() => {
       const origQueuePrompt = app.queuePrompt;
-      app.queuePrompt = async function(...args) {
+      app.queuePrompt = function(...args) {
         execNodes("before_queued", args);
-        const r = await origQueuePrompt.apply(this, arguments);
-        return r;
+        return origQueuePrompt.apply(this, args);
       }
 
       api.addEventListener("promptQueued", function(...args) {


### PR DESCRIPTION
## Why

`FL_JS` and `FL_WF_Agent` wrap `app.queuePrompt()` to run their `before_queued` hooks. Both wrappers unnecessarily awaited the original promise before returning it.

When the underlying prompt request failed, that extra `await` inserted both extension wrappers into the async stack trace. For example, a backend `403 PARTNER_NODE_DISABLED` rejection appeared to originate at `fl_js.js` and `fl_wf_agent.js`, even though neither extension caused or handled the rejection. This makes browser-console diagnosis misleading.

## Root cause

The wrappers used `async` + `await` only to return the original result:

```js
const r = await origQueuePrompt.apply(this, arguments);
return r;
```

That creates extension-owned async frames for every downstream queue failure.

## Change

- Keep running `before_queued` synchronously with the same arguments.
- Return the original `queuePrompt` promise directly.
- Preserve fulfillment values and rejection behavior without adding extension async frames.
- Apply the same fix to both wrappers shown in the affected stack.

This does **not** bypass or alter backend authorization. Workspace policy rejections still propagate to ComfyUI's existing error handling.

## Verification

- `node --check web/nodes/utility/fl_js.js`
- `node --check web/nodes/wip/fl_wf_agent.js`
- `git diff --check`
