### PR TITLE
chore(deps): clean up Python dependency declarations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,33 @@ name = "comfyui_fill-nodes"
 description = "Fill-Nodes is a versatile collection of custom nodes for ComfyUI that extends functionality across multiple domains. Features include advanced image processing (pixelation, slicing, masking), visual effects generation (glitch, halftone, pixel art), comprehensive file handling (PDF creation/extraction, Google Drive integration), AI model interfaces (GPT, DALL-E, Hugging Face), utility nodes for workflow enhancement, and specialized tools for video processing, captioning, and batch operations. The pack provides both practical workflow solutions and creative tools within a unified node collection."
 version = "2.28.1"
 license = {file = "LICENSE"}
-dependencies = ["librosa", "sounddevice", "glitch_this", "PyOpenGL", "glfw", "scipy>=1.13.1", "requests", "aiohttp", "moviepy", "matplotlib", "reportlab", "openai", "PyPDF2", "pdf2image", "PyMuPDF", "reportlab", "PyPDF2", "ollama", "kornia", "opencv-python", "gdown", "open_clip_torch", "google-genai"]
+dependencies = [
+    "librosa",
+    "glitch_this",
+    "PyOpenGL",
+    "glfw",
+    "scipy>=1.13.1",
+    "requests",
+    "aiohttp",
+    "imageio[ffmpeg]",
+    "matplotlib",
+    "reportlab",
+    "openai",
+    "PyPDF2",
+    "PyMuPDF",
+    "ollama",
+    "kornia",
+    "opencv-python",
+    "gdown",
+    "open_clip_torch",
+    "google-genai>=1.66.0,<2.0.0",
+    "google-cloud-storage",
+    "fal-client",
+    "runwayml",
+    "httpx",
+    "huggingface_hub",
+    "scikit-learn",
+]
 
 [project.urls]
 Repository = "https://github.com/filliptm/ComfyUI_Fill-Nodes"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,16 @@
 librosa
-sounddevice
 glitch_this
 PyOpenGL
 glfw
-scipy >=1.13.1
+scipy>=1.13.1
 requests
 aiohttp
-moviepy==1.0.3
+imageio[ffmpeg]
 matplotlib
 reportlab
 openai
 PyPDF2
-pdf2image
 PyMuPDF
-reportlab
-PyPDF2
 ollama
 kornia
 opencv-python
@@ -26,3 +22,4 @@ fal-client
 runwayml
 httpx
 huggingface_hub
+scikit-learn


### PR DESCRIPTION
## Summary

- remove unused `moviepy`, `sounddevice`, and `pdf2image` dependencies
- declare `imageio[ffmpeg]` and `scikit-learn` directly instead of relying on transitive installations
- remove duplicate PDF dependency entries
- keep `requirements.txt` and `pyproject.toml` consistent

## Why

The project no longer imports MoviePy or pdf2image, and sounddevice is not used by the current source code.

MoviePy 1.0.3 also requires `decorator<5.0`, which conflicts with the `decorator>=5.2.1` requirement used by librosa 1.x. Although dependency resolvers may silently install an older librosa release, the stale MoviePy dependency unnecessarily restricts the shared ComfyUI environment.

`FL_SaveWebM` imports imageio and uses its ffmpeg backend, while `FL_PixelArt` imports scikit-learn directly. Declaring these packages explicitly avoids depending on unrelated transitive dependencies.

## Impact

This changes dependency declarations only. No node interfaces or runtime behavior have been changed.

Fresh installations will no longer install the unused packages, and both supported dependency manifests now produce the same environment.

## Validation

- resolved `requirements.txt` with uv for Python 3.11 and 3.13
- resolved `pyproject.toml` with uv for Python 3.11 and 3.13
- confirmed both manifests contain the same direct dependencies and version constraints
- confirmed the removed packages are no longer referenced by the project

---

AI-assisted contribution: OpenAI Codex (GPT-5.6-sol) assisted with the dependency audit, implementation, validation, and PR documentation.